### PR TITLE
added css word-wrap as workaround for low-resolution screens in order…

### DIFF
--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -243,6 +243,8 @@ ul.edoweb-facets-available>li span {
 
 ul.edoweb-facets-available a {
   color: #004678;
+  word-wrap: break-word;
+  break-word: break-word;
 }
 
 


### PR DESCRIPTION
… to prevent facets-bar to supersede result table.

Background: as long as "http://purl.org/dc/terms/BibliographicResource" is not replaced by any translation, these very long string widens the facets bar in a way that the result table is moved under the facets bar. This enormous harms the usability of the web site!    
