### PR TITLE
striped vertical spaces from default item table

### DIFF
--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -49,7 +49,7 @@ body {
 
 body, table, input, label, .fieldset-legend, .ui-widget {
   font-family: "TabletGothicNarrow", "roboto_condensedregular",sans-serif;
-  line-height: 1.5em;
+  line-height: 1.2em;
   color: #4b4b4d;
   max-width: 1650px;
 }
@@ -423,6 +423,25 @@ ul.edoweb-facets-available a:hover {
 
 .default .field-name-field-edoweb-struct-child thead {
   display:none;
+}
+
+.default .field-name-field-edoweb-creator td {
+  padding: 0px;
+  margin:0px;
+
+}
+
+.default .field-name-field-edoweb-creator td h1 {
+  
+  margin:0px;
+
+}
+
+.default .field td h1 {
+  font-size: 1.1em;
+  padding: 0px;
+  margin-top: 0px;
+
 }
 
 /* .field-name-field-edoweb-struct-child .field-label-above .field-label {


### PR DESCRIPTION
remove vertical spaces from the default field tables in order to present a better readable view for items
