### PR TITLE
hide fundingId

### DIFF
--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -974,7 +974,11 @@ do not display this fields
 .resourceTable .hasItem,
 .resourceTable .predecessor, 
 .resourceTable .successor, 
-.resourceTable .corporateBodyForTitle
+.resourceTable .corporateBodyForTitle,
+.resourceTable .funding, 
+.resourceTable .fundingProgram, 
+.resourceTable .projectId,
+.resourceTable .fundingId
 { 
 	display: none;
 }


### PR DESCRIPTION
Das Feld FundingId wird von der Erfassungsmaske benötigt, soll aber nicht angezeigt werden.